### PR TITLE
Chore / 3491 add a11y tests for sl-dialog

### DIFF
--- a/e2e/tests/a11y/a11y-sl-dialog.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-dialog.spec.ts
@@ -50,14 +50,14 @@ test.describe('sl-dialog accessibility', () => {
 
     let focusedOn = await getFocusedElement(page);
     expect(focusedOn).toBe('Test');
-    expect(page.getByRole('button', { name: 'Test' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Test' })).toBeVisible();
 
     await page.keyboard.press('Space');
     await page.keyboard.press('Tab');
 
     focusedOn = await getFocusedElement(page);
     expect(focusedOn).toBe('Close');
-    expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
 
     await page.keyboard.press('Space');
 
@@ -74,13 +74,13 @@ test.describe('sl-dialog accessibility', () => {
 
     let focusedOn = await getFocusedElement(page);
     expect(focusedOn).toBe('Test');
-    expect(page.getByRole('button', { name: 'Test' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Test' })).toBeVisible();
 
     await page.keyboard.press('Space');
 
     focusedOn = await getFocusedElement(page);
     expect(focusedOn).toBe('Close');
-    expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
 
     await page.keyboard.press('Space');
 

--- a/e2e/tests/a11y/a11y-sl-dialog.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-dialog.spec.ts
@@ -50,6 +50,7 @@ test.describe('sl-dialog accessibility', () => {
     for (const activeElement of activeElements) {
       const focusedOn = await getFocusedElement(page);
       expect(focusedOn).toBe(activeElement);
+      expect(page.getByRole('button', { name: activeElement })).toBeVisible();
       await page.keyboard.press('Space');
       // Firefox and Webkit require an additional tab press to focus the next element after opening the dialog
       await page.keyboard.press('Tab');
@@ -66,6 +67,7 @@ test.describe('sl-dialog accessibility', () => {
     for (const activeElement of activeElements) {
       const focusedOn = await getFocusedElement(page);
       expect(focusedOn).toBe(activeElement);
+      expect(page.getByRole('button', { name: activeElement })).toBeVisible();
       await page.keyboard.press('Space');
     }
   });

--- a/e2e/tests/a11y/a11y-sl-dialog.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-dialog.spec.ts
@@ -32,9 +32,11 @@ test.describe('sl-dialog accessibility', () => {
   });
 
   test('component fits without horizontal scroll', async ({ page }) => {
+    const item = page.getByRole('button', { name: 'Test' });
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-dialog'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
+    await item.click();
 
     const hasOverflow = await hasMainHorizontalOverflow(page);
     expect(hasOverflow).toBe(false);
@@ -42,34 +44,49 @@ test.describe('sl-dialog accessibility', () => {
 
   test('should have correct tab order', async ({ page, browserName }) => {
     test.skip(browserName === 'chromium');
-    const activeElements = ['Test', 'Close'] as const;
 
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
     await page.keyboard.press('Tab');
 
-    for (const activeElement of activeElements) {
-      const focusedOn = await getFocusedElement(page);
-      expect(focusedOn).toBe(activeElement);
-      expect(page.getByRole('button', { name: activeElement })).toBeVisible();
-      await page.keyboard.press('Space');
-      // Firefox and Webkit require an additional tab press to focus the next element after opening the dialog
-      await page.keyboard.press('Tab');
-    }
+    let focusedOn = await getFocusedElement(page);
+    expect(focusedOn).toBe('Test');
+    expect(page.getByRole('button', { name: 'Test' })).toBeVisible();
+
+    await page.keyboard.press('Space');
+    await page.keyboard.press('Tab');
+
+    focusedOn = await getFocusedElement(page);
+    expect(focusedOn).toBe('Close');
+    expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+
+    await page.keyboard.press('Space');
+
+    await expect(page.getByRole('button', { name: 'Close' })).not.toBeVisible();
+    focusedOn = await getFocusedElement(page);
+    expect(focusedOn).toBe('Test');
   });
 
   test('should have correct tab order in chromium', async ({ page, browserName }) => {
     test.skip(browserName !== 'chromium');
-    const activeElements = ['Test', 'Close'] as const;
 
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
     await page.keyboard.press('Tab');
 
-    for (const activeElement of activeElements) {
-      const focusedOn = await getFocusedElement(page);
-      expect(focusedOn).toBe(activeElement);
-      expect(page.getByRole('button', { name: activeElement })).toBeVisible();
-      await page.keyboard.press('Space');
-    }
+    let focusedOn = await getFocusedElement(page);
+    expect(focusedOn).toBe('Test');
+    expect(page.getByRole('button', { name: 'Test' })).toBeVisible();
+
+    await page.keyboard.press('Space');
+
+    focusedOn = await getFocusedElement(page);
+    expect(focusedOn).toBe('Close');
+    expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+
+    await page.keyboard.press('Space');
+
+    await expect(page.getByRole('button', { name: 'Close' })).not.toBeVisible();
+    focusedOn = await getFocusedElement(page);
+    expect(focusedOn).toBe('Test');
   });
 
   test(`should be activated and closed with Enter key`, async ({ page }) => {

--- a/e2e/tests/a11y/a11y-sl-dialog.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-dialog.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { hasMainHorizontalOverflow } from '../../utils/checkForHorizontalScroll.js';
+
+test.describe('sl-dialog accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/sl-dialog');
+  });
+
+  test('should have no accessibility violations', async ({ page }) => {
+    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const results = await axe.analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('should have no accessibility violations in mobile viewport', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
+    await page.goto('/sl-dialog'); // for Firefox to properly apply the viewport size before page load
+    await page.getByRole('button', { name: 'Collapse navigation' }).click();
+    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const results = await axe.analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('component fits without horizontal scroll', async ({ page }) => {
+    await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
+    await page.goto('/sl-dialog'); // for Firefox to properly apply the viewport size before page load
+    await page.getByRole('button', { name: 'Collapse navigation' }).click();
+
+    const hasOverflow = await hasMainHorizontalOverflow(page);
+    expect(hasOverflow).toBe(false);
+  });
+
+  test('should have correct tab order', async ({ page }) => {
+    const item = page.getByRole('button', { name: 'Test' });
+
+    await page.getByRole('button', { name: 'Collapse navigation' }).click();
+
+    await page.keyboard.press('Tab');
+    await expect(item).toBeFocused();
+
+    await page.keyboard.press('Enter');
+    
+    const focusedElement = await page.evaluate(() => {
+      const active = document.activeElement;
+      return active?.tagName;
+    });
+    expect(['SL-DIALOG', 'SL-BUTTON']).toContain(focusedElement);
+  });
+
+  test(`should be activated and closed with Enter key`, async ({ page }) => {
+    const item = page.getByRole('button', { name: 'Test' });
+    const dialog = page.locator('sl-dialog');
+    const closeButton = page.getByRole('button', { name: 'Close' });
+
+    await item.focus();
+    await page.keyboard.press('Enter');
+    await expect(dialog).toBeVisible();
+
+    await closeButton.focus();
+    await page.keyboard.press('Enter');
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test(`should be activated and closed with Space key`, async ({ page }) => {
+    const item = page.getByRole('button', { name: 'Test' });
+    const dialog = page.locator('sl-dialog');
+    const closeButton = page.getByRole('button', { name: 'Close' });
+
+    await item.focus();
+    await page.keyboard.press('Space');
+    await expect(dialog).toBeVisible();
+
+    await closeButton.focus();
+    await page.keyboard.press('Space');
+    await expect(dialog).not.toBeVisible();
+  });
+});

--- a/e2e/tests/a11y/a11y-sl-dialog.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-dialog.spec.ts
@@ -8,6 +8,9 @@ test.describe('sl-dialog accessibility', () => {
   });
 
   test('should have no accessibility violations', async ({ page }) => {
+    const item = page.getByRole('button', { name: 'Test' });
+    await item.click();
+
     const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
@@ -16,9 +19,12 @@ test.describe('sl-dialog accessibility', () => {
   test('should have no accessibility violations in mobile viewport', async ({
     page,
   }) => {
+    const item = page.getByRole('button', { name: 'Test' });
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-dialog'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
+    await item.click();
+
     const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
@@ -35,19 +41,20 @@ test.describe('sl-dialog accessibility', () => {
 
   test('should have correct tab order', async ({ page }) => {
     const item = page.getByRole('button', { name: 'Test' });
+    const dialog = page.locator('sl-dialog');
 
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
 
     await page.keyboard.press('Tab');
     await expect(item).toBeFocused();
-
     await page.keyboard.press('Enter');
     
-    const focusedElement = await page.evaluate(() => {
+    await expect(dialog).toBeVisible();
+    const focusIsInDialog = await page.evaluate(() => {
       const active = document.activeElement;
-      return active?.tagName;
+      return !!active && (active.tagName === 'SL-DIALOG' || active.closest('sl-dialog') !== null);
     });
-    expect(['SL-DIALOG', 'SL-BUTTON']).toContain(focusedElement);
+    expect(focusIsInDialog).toBe(true);
   });
 
   test(`should be activated and closed with Enter key`, async ({ page }) => {
@@ -77,4 +84,19 @@ test.describe('sl-dialog accessibility', () => {
     await page.keyboard.press('Space');
     await expect(dialog).not.toBeVisible();
   });
+
+  test(`should be closed with Escape key`, async ({ page }) => {
+    const item = page.getByRole('button', { name: 'Test' });
+    const dialog = page.locator('sl-dialog');
+    const closeButton = page.getByRole('button', { name: 'Close' });
+
+    await item.focus();
+    await page.keyboard.press('Enter');
+    await expect(dialog).toBeVisible();
+
+    await closeButton.focus();
+    await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible();
+  });
+
 });

--- a/e2e/tests/a11y/a11y-sl-dialog.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-dialog.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import { hasMainHorizontalOverflow } from '../../utils/checkForHorizontalScroll.js';
+import { getFocusedElement } from '../../utils/getFocusedElement.js';
 
 test.describe('sl-dialog accessibility', () => {
   test.beforeEach(async ({ page }) => {
@@ -39,22 +40,34 @@ test.describe('sl-dialog accessibility', () => {
     expect(hasOverflow).toBe(false);
   });
 
-  test('should have correct tab order', async ({ page }) => {
-    const item = page.getByRole('button', { name: 'Test' });
-    const dialog = page.locator('sl-dialog');
+  test('should have correct tab order', async ({ page, browserName }) => {
+    test.skip(browserName === 'chromium');
+    const activeElements = ['Test', 'Close'] as const;
 
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
-
     await page.keyboard.press('Tab');
-    await expect(item).toBeFocused();
-    await page.keyboard.press('Enter');
-    
-    await expect(dialog).toBeVisible();
-    const focusIsInDialog = await page.evaluate(() => {
-      const active = document.activeElement;
-      return !!active && (active.tagName === 'SL-DIALOG' || active.closest('sl-dialog') !== null);
-    });
-    expect(focusIsInDialog).toBe(true);
+
+    for (const activeElement of activeElements) {
+      const focusedOn = await getFocusedElement(page);
+      expect(focusedOn).toBe(activeElement);
+      await page.keyboard.press('Space');
+      // Firefox and Webkit require an additional tab press to focus the next element after opening the dialog
+      await page.keyboard.press('Tab');
+    }
+  });
+
+  test('should have correct tab order in chromium', async ({ page, browserName }) => {
+    test.skip(browserName !== 'chromium');
+    const activeElements = ['Test', 'Close'] as const;
+
+    await page.getByRole('button', { name: 'Collapse navigation' }).click();
+    await page.keyboard.press('Tab');
+
+    for (const activeElement of activeElements) {
+      const focusedOn = await getFocusedElement(page);
+      expect(focusedOn).toBe(activeElement);
+      await page.keyboard.press('Space');
+    }
   });
 
   test(`should be activated and closed with Enter key`, async ({ page }) => {
@@ -98,5 +111,4 @@ test.describe('sl-dialog accessibility', () => {
     await page.keyboard.press('Escape');
     await expect(dialog).not.toBeVisible();
   });
-
 });

--- a/e2e/utils/getFocusedElement.ts
+++ b/e2e/utils/getFocusedElement.ts
@@ -18,12 +18,11 @@ export async function getFocusedElement(page: Page): Promise<string | null> {
     if (!el) return null;
 
     // Check for aria-label on deepest element (highest priority)
-    if (el.hasAttribute('aria-label')) {
-      return (el.getAttribute('aria-label') ?? '').trim();
-    }
+    const ariaLabel = el.getAttribute('aria-label')?.trim();
+    if (ariaLabel) return ariaLabel;
 
-    // Try to get innerText from the deepest element
-    const deepestText = el.innerText?.trim();
+    // Try to get innerText from the deepest element (HTMLElement only)
+    const deepestText = el instanceof HTMLElement ? el.innerText.trim() : '';
     
     if (deepestText) {
       return deepestText;
@@ -31,12 +30,11 @@ export async function getFocusedElement(page: Page): Promise<string | null> {
 
     // If deepest has no innerText, try the second-to-deepest element
     if (prevEl) {
-      // Check for aria-label on second-to-deepest
-      if (prevEl.hasAttribute('aria-label')) {
-        return (prevEl.getAttribute('aria-label') ?? '').trim();
-      }
+      // Check for aria-label on second-to-deepest (only return if non-empty)
+      const prevAriaLabel = prevEl.getAttribute('aria-label')?.trim();
+      if (prevAriaLabel) return prevAriaLabel;
 
-      const prevText = prevEl.innerText?.trim();
+      const prevText = prevEl instanceof HTMLElement ? prevEl.innerText.trim() : '';
       if (prevText) {
         return prevText;
       }

--- a/e2e/utils/getFocusedElement.ts
+++ b/e2e/utils/getFocusedElement.ts
@@ -34,8 +34,9 @@ export async function getFocusedElement(page: Page): Promise<string | null> {
       if (prevAriaLabel) return prevAriaLabel;
 
       const prevText = prevEl instanceof HTMLElement ? prevEl.innerText.trim() : '';
+      const MAX_PREV_TEXT_LENGTH = 100;
       // Only use prevText if it's reasonably short (avoid large container text like combobox options)
-      if (prevText && prevText.length < 100) {
+      if (prevText && prevText.length < MAX_PREV_TEXT_LENGTH) {
         return prevText;
       }
     }

--- a/e2e/utils/getFocusedElement.ts
+++ b/e2e/utils/getFocusedElement.ts
@@ -2,20 +2,52 @@ import type { Page } from '@playwright/test';
 
 export async function getFocusedElement(page: Page): Promise<string | null> {
   return page.evaluate(() => {
-    let el = document.activeElement;
-    while (el?.shadowRoot?.activeElement) {
-      el = el.shadowRoot.activeElement;
-    }
+    let el = document.activeElement as Element | null;
 
     if (!el) return null;
 
-    // Clone the element to avoid modifying the DOM
-    const clone = el.cloneNode(true) as Element;
+    // Traverse through shadow DOM levels, keeping track of previous element
+    let prevEl: Element | null = null;
+    while (el?.shadowRoot?.activeElement) {
+      prevEl = el;
+      el = el.shadowRoot.activeElement as Element;
+    }
 
-    // Remove all aria-hidden elements and their content
-    const hiddenElements = clone.querySelectorAll('[aria-hidden="true"]');
-    hiddenElements.forEach((hiddenEl) => hiddenEl.remove());
+    // el is now the deepest element, prevEl is the second-to-deepest
 
-    return clone.textContent?.trim() ?? null;
+    if (!el) return null;
+
+    // Check for aria-label on deepest element (highest priority)
+    if (el.hasAttribute('aria-label')) {
+      return (el.getAttribute('aria-label') ?? '').trim();
+    }
+
+    // Try to get innerText from the deepest element
+    const deepestText = el.innerText?.trim();
+    
+    if (deepestText) {
+      return deepestText;
+    }
+
+    // If deepest has no innerText, try the second-to-deepest element
+    if (prevEl) {
+      // Check for aria-label on second-to-deepest
+      if (prevEl.hasAttribute('aria-label')) {
+        return (prevEl.getAttribute('aria-label') ?? '').trim();
+      }
+
+      const prevText = prevEl.innerText?.trim();
+      if (prevText) {
+        return prevText;
+      }
+
+      // Fallback to textContent of second-to-deepest
+      const prevContentText = prevEl.textContent?.trim();
+      return prevContentText || null;
+    }
+
+    // Fallback: use textContent of deepest if innerText is empty
+    const contentText = el.textContent?.trim();
+    return contentText || null;
   });
 }

--- a/e2e/utils/getFocusedElement.ts
+++ b/e2e/utils/getFocusedElement.ts
@@ -30,18 +30,14 @@ export async function getFocusedElement(page: Page): Promise<string | null> {
 
     // If deepest has no innerText, try the second-to-deepest element
     if (prevEl) {
-      // Check for aria-label on second-to-deepest (only return if non-empty)
       const prevAriaLabel = prevEl.getAttribute('aria-label')?.trim();
       if (prevAriaLabel) return prevAriaLabel;
 
       const prevText = prevEl instanceof HTMLElement ? prevEl.innerText.trim() : '';
-      if (prevText) {
+      // Only use prevText if it's reasonably short (avoid large container text like combobox options)
+      if (prevText && prevText.length < 100) {
         return prevText;
       }
-
-      // Fallback to textContent of second-to-deepest
-      const prevContentText = prevEl.textContent?.trim();
-      return prevContentText || null;
     }
 
     // Fallback: use textContent of deepest if innerText is empty


### PR DESCRIPTION
close: [#3491](https://github.com/sl-design-system/components/issues/3491)

- Add a11y test for `sl-dialog`
- Fixes helper `getFocusedElements` so it returns button names