### PR TITLE
Chore / 3527 add a11y tests for sl-form-field

### DIFF
--- a/e2e/tests/a11y/a11y-sl-form-field.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-form-field.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { hasMainHorizontalOverflow } from '../../utils/checkForHorizontalScroll.js';
+import { getFocusedElement } from '../../utils/getFocusedElement.js';
+
+test.describe('sl-form-field accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/sl-form-field');
+  });
+
+  test('should have no accessibility violations', async ({ page }) => {
+    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const results = await axe.analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('should have no accessibility violations in mobile viewport', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
+    await page.goto('/sl-form-field'); // for Firefox to properly apply the viewport size before page load
+    await page.getByRole('button', { name: 'Collapse navigation' }).click();
+
+    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const results = await axe.analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test('component fits without horizontal scroll', async ({ page }) => {
+    await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
+    await page.goto('/sl-form-field'); // for Firefox to properly apply the viewport size before page load
+    await page.getByRole('button', { name: 'Collapse navigation' }).click();
+
+    const hasOverflow = await hasMainHorizontalOverflow(page);
+    expect(hasOverflow).toBe(false);
+  });
+
+  test('should have correct tab order', async ({ page }) => {
+    await page.getByRole('button', { name: 'Collapse navigation' }).click();
+    await page.keyboard.press('Tab');
+
+    let focusedOn = await getFocusedElement(page);
+    expect(focusedOn).toBe('Enabled');
+
+    await page.keyboard.press('Tab');
+
+    focusedOn = await getFocusedElement(page);
+    expect(focusedOn).not.toBe('Disabled');
+  });
+
+  test('should have accessible name', async ({ page }) => {
+    const active = page
+      .locator('sl-form-field')
+      .filter({ hasText: 'Enabled' })
+      .getByRole('textbox');
+
+    const disabled = page
+      .locator('sl-form-field')
+      .filter({ hasText: 'Disabled' })
+      .getByRole('textbox');
+
+    await expect(active).toHaveAccessibleName('Enabled');
+    await expect(disabled).toHaveAccessibleName('Disabled');
+  });
+
+  test(`should be keyboard operable`, async ({ page }) => {
+    const item = page
+      .locator('sl-form-field')
+      .filter({ hasText: 'Enabled' })
+      .getByRole('textbox');
+    
+    await page.getByRole('button', { name: 'Collapse navigation' }).click();
+    await page.keyboard.press('Tab');
+    await page.keyboard.type('Test 1');
+
+    await expect(item).toHaveValue('Test 1');
+  });
+});

--- a/e2e/utils/getFocusedElement.ts
+++ b/e2e/utils/getFocusedElement.ts
@@ -28,6 +28,24 @@ export async function getFocusedElement(page: Page): Promise<string | null> {
       return deepestText;
     }
 
+    // If deepest is an input, check for associated label via id/for attributes
+    if (el instanceof HTMLInputElement) {
+      const inputId = el.getAttribute('id');
+      if (inputId) {
+        // First try to find label in the same shadow root as the input
+        const root = el.getRootNode() as Document | ShadowRoot;
+        let label = root.querySelector(`label[for="${inputId}"]`) as HTMLLabelElement | null;
+        
+        // If not found and we're in a shadow DOM, also try the document root
+        if (!label && root instanceof ShadowRoot) {
+          label = document.querySelector(`label[for="${inputId}"]`) as HTMLLabelElement | null;
+        }
+        
+        const labelText = label?.textContent?.trim();
+        if (labelText) return labelText;
+      }
+    }
+
     // If deepest has no innerText, try the second-to-deepest element
     if (prevEl) {
       const prevAriaLabel = prevEl.getAttribute('aria-label')?.trim();

--- a/e2e/utils/getFocusedElement.ts
+++ b/e2e/utils/getFocusedElement.ts
@@ -28,24 +28,35 @@ export async function getFocusedElement(page: Page): Promise<string | null> {
       return deepestText;
     }
 
-    // If deepest is an input, check for associated label via id/for attributes
-    if (el instanceof HTMLInputElement) {
+    // If deepest is a form control (input, textarea, select), check for associated label via id/for attributes
+    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement || el instanceof HTMLSelectElement) {
       const associatedLabelText = el.labels?.[0]?.textContent?.trim();
       if (associatedLabelText) return associatedLabelText;
-      const inputId = el.getAttribute('id');
       
-      if (inputId) {
-        const root = el.getRootNode() as Document | ShadowRoot;
-        const findLabel = (scope: Document | ShadowRoot) =>
-           Array.from(scope.querySelectorAll('label')).find(
-             (l) => l instanceof HTMLLabelElement && l.htmlFor === inputId,
-           ) as HTMLLabelElement | undefined;
-         const label =
-           findLabel(root) ??
-           (root instanceof ShadowRoot ? findLabel(el.ownerDocument) : undefined);
-         const labelText = label?.textContent?.trim();
-         if (labelText) return labelText;
-       }
+      const elementId = el.getAttribute('id');
+      if (elementId) {
+        // Traverse up the composed tree to find label in any shadow root or document
+        let currentRoot: Document | ShadowRoot = el.getRootNode() as Document | ShadowRoot;
+        
+        while (currentRoot) {
+          const label = Array.from(currentRoot.querySelectorAll('label')).find(
+            (l) => l instanceof HTMLLabelElement && l.htmlFor === elementId,
+          ) as HTMLLabelElement | undefined;
+          
+          if (label) {
+            const labelText = label.textContent?.trim();
+            if (labelText) return labelText;
+          }
+          
+          // Move up to parent shadow root
+          if (currentRoot instanceof ShadowRoot) {
+            currentRoot = currentRoot.host.getRootNode() as Document | ShadowRoot;
+          } else {
+            // We're at the document, no more parents
+            break;
+          }
+        }
+      }
     }
 
     // If deepest has no innerText, try the second-to-deepest element

--- a/e2e/utils/getFocusedElement.ts
+++ b/e2e/utils/getFocusedElement.ts
@@ -30,20 +30,20 @@ export async function getFocusedElement(page: Page): Promise<string | null> {
 
     // If deepest is an input, check for associated label via id/for attributes
     if (el instanceof HTMLInputElement) {
+      const associatedLabelText = el.labels?.[0]?.textContent?.trim();
+      if (associatedLabelText) return associatedLabelText;
       const inputId = el.getAttribute('id');
+      
       if (inputId) {
-        // First try to find label in the same shadow root as the input
         const root = el.getRootNode() as Document | ShadowRoot;
-        let label = root.querySelector(`label[for="${inputId}"]`) as HTMLLabelElement | null;
-        
-        // If not found and we're in a shadow DOM, also try the document root
-        if (!label && root instanceof ShadowRoot) {
-          label = document.querySelector(`label[for="${inputId}"]`) as HTMLLabelElement | null;
-        }
-        
-        const labelText = label?.textContent?.trim();
-        if (labelText) return labelText;
-      }
+        const findLabel = (scope: Document | ShadowRoot) =>
+           Array.from(scope.querySelectorAll('label')).find(
+             (l) => l instanceof HTMLLabelElement && l.htmlFor === inputId,
+           ) as HTMLLabelElement | undefined;
+         const label = findLabel(root) ?? (root instanceof ShadowRoot ? findLabel(document) : undefined);
+         const labelText = label?.textContent?.trim();
+         if (labelText) return labelText;
+       }
     }
 
     // If deepest has no innerText, try the second-to-deepest element

--- a/e2e/utils/getFocusedElement.ts
+++ b/e2e/utils/getFocusedElement.ts
@@ -40,7 +40,9 @@ export async function getFocusedElement(page: Page): Promise<string | null> {
            Array.from(scope.querySelectorAll('label')).find(
              (l) => l instanceof HTMLLabelElement && l.htmlFor === inputId,
            ) as HTMLLabelElement | undefined;
-         const label = findLabel(root) ?? (root instanceof ShadowRoot ? findLabel(document) : undefined);
+         const label =
+           findLabel(root) ??
+           (root instanceof ShadowRoot ? findLabel(el.ownerDocument) : undefined);
          const labelText = label?.textContent?.trim();
          if (labelText) return labelText;
        }


### PR DESCRIPTION
close: [#3527](https://github.com/sl-design-system/components/issues/3527)
- add a11y tests for sl-form-field
- add possibility to recognize input label as element name in getFocusedElement helper function