### PR TITLE
Fix / 3535 tooltip axe core test and format a11y tests

### DIFF
--- a/e2e/tests/a11y/a11y-sl-accordion.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-accordion.spec.ts
@@ -12,7 +12,14 @@ test.describe('sl-accordion accessibility', () => {
     page,
   }) => {
     await page.locator('summary').filter({ hasText: 'Test 1' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -24,7 +31,14 @@ test.describe('sl-accordion accessibility', () => {
     await page.goto('/sl-accordion'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
     await page.locator('sl-accordion').filter({ hasText: 'Test 1' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/tests/a11y/a11y-sl-avatar.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-avatar.spec.ts
@@ -11,7 +11,14 @@ test.describe('sl-avatar accessibility', () => {
   test('should have no accessibility violations in standard viewport', async ({
     page,
   }) => {
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -22,7 +29,14 @@ test.describe('sl-avatar accessibility', () => {
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-avatar'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/tests/a11y/a11y-sl-breadcrumbs.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-breadcrumbs.spec.ts
@@ -13,7 +13,14 @@ test.describe('sl-breadcrumbs accessibility', () => {
   }) => {
     await page.setViewportSize({ width: 1200, height: 800 });
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -24,7 +31,14 @@ test.describe('sl-breadcrumbs accessibility', () => {
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-breadcrumbs'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/tests/a11y/a11y-sl-button-bar.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-button-bar.spec.ts
@@ -8,7 +8,14 @@ test.describe('sl-button-bar accessibility', () => {
   });
 
   test('should have no accessibility violations', async ({ page }) => {
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -19,7 +26,14 @@ test.describe('sl-button-bar accessibility', () => {
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-button-bar'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/tests/a11y/a11y-sl-button.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-button.spec.ts
@@ -10,7 +10,14 @@ test.describe('sl-button accessibility', () => {
   test('should have no accessibility violations in standard viewport', async ({
     page,
   }) => {
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -21,7 +28,14 @@ test.describe('sl-button accessibility', () => {
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-button'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/tests/a11y/a11y-sl-callout.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-callout.spec.ts
@@ -10,7 +10,14 @@ test.describe('sl-callout accessibility', () => {
   test('should have no accessibility violations in standard viewport', async ({
     page,
   }) => {
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -21,7 +28,14 @@ test.describe('sl-callout accessibility', () => {
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-callout'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/tests/a11y/a11y-sl-card.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-card.spec.ts
@@ -10,7 +10,14 @@ test.describe('sl-card accessibility', () => {
   test('should have no accessibility violations in standard viewport', async ({
     page,
   }) => {
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -21,7 +28,14 @@ test.describe('sl-card accessibility', () => {
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-card'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/tests/a11y/a11y-sl-checkbox.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-checkbox.spec.ts
@@ -10,7 +10,14 @@ test.describe('sl-checkbox accessibility', () => {
   test('should have no accessibility violations in standard viewport', async ({
     page,
   }) => {
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -21,7 +28,14 @@ test.describe('sl-checkbox accessibility', () => {
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-checkbox'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/tests/a11y/a11y-sl-dialog.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-dialog.spec.ts
@@ -12,7 +12,14 @@ test.describe('sl-dialog accessibility', () => {
     const item = page.getByRole('button', { name: 'Test' });
     await item.click();
 
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -26,7 +33,14 @@ test.describe('sl-dialog accessibility', () => {
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
     await item.click();
 
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -66,7 +80,10 @@ test.describe('sl-dialog accessibility', () => {
     expect(focusedOn).toBe('Test');
   });
 
-  test('should have correct tab order in chromium', async ({ page, browserName }) => {
+  test('should have correct tab order in chromium', async ({
+    page,
+    browserName,
+  }) => {
     test.skip(browserName !== 'chromium');
 
     await page.getByRole('button', { name: 'Collapse navigation' }).click();

--- a/e2e/tests/a11y/a11y-sl-form-field.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-form-field.spec.ts
@@ -9,7 +9,14 @@ test.describe('sl-form-field accessibility', () => {
   });
 
   test('should have no accessibility violations', async ({ page }) => {
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -21,7 +28,14 @@ test.describe('sl-form-field accessibility', () => {
     await page.goto('/sl-form-field'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
 
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -68,7 +82,7 @@ test.describe('sl-form-field accessibility', () => {
       .locator('sl-form-field')
       .filter({ hasText: 'Enabled' })
       .getByRole('textbox');
-    
+
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
     await page.keyboard.press('Tab');
     await page.keyboard.type('Test 1');

--- a/e2e/tests/a11y/a11y-sl-form.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-form.spec.ts
@@ -5,8 +5,16 @@ import { hasMainHorizontalOverflow } from '../../utils/checkForHorizontalScroll.
 
 const variants = [
   { name: 'sl-form a11y', path: '/sl-form', angularOnly: false },
-  { name: 'sl-form (reactive) a11y', path: '/sl-form-reactive', angularOnly: true },
-  { name: 'sl-form (template) a11y', path: '/sl-form-template', angularOnly: true },
+  {
+    name: 'sl-form (reactive) a11y',
+    path: '/sl-form-reactive',
+    angularOnly: true,
+  },
+  {
+    name: 'sl-form (template) a11y',
+    path: '/sl-form-template',
+    angularOnly: true,
+  },
 ];
 
 for (const { name, path, angularOnly } of variants) {
@@ -23,7 +31,14 @@ for (const { name, path, angularOnly } of variants) {
     test('should have no accessibility violations in standard viewport', async ({
       page,
     }) => {
-      const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+      const axe = new AxeBuilder({ page }).withTags([
+        'wcag2a',
+        'wcag2aa',
+        'wcag21a',
+        'wcag21aa',
+        'wcag22a',
+        'wcag22aa',
+      ]);
       const results = await axe.analyze();
       expect(results.violations).toEqual([]);
     });
@@ -34,7 +49,14 @@ for (const { name, path, angularOnly } of variants) {
       await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
       await page.goto(path); // for Firefox to properly apply the viewport size before page load
       await page.getByRole('button', { name: 'Collapse navigation' }).click();
-      const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+      const axe = new AxeBuilder({ page }).withTags([
+        'wcag2a',
+        'wcag2aa',
+        'wcag21a',
+        'wcag21aa',
+        'wcag22a',
+        'wcag22aa',
+      ]);
       const results = await axe.analyze();
       expect(results.violations).toEqual([]);
     });
@@ -49,8 +71,14 @@ for (const { name, path, angularOnly } of variants) {
     });
 
     test('should have correct accessible names', async ({ page }) => {
-      const input = page.locator('sl-form-field').filter({ hasText: 'Name' }).getByRole('textbox');
-      const checkbox = page.locator('sl-form-field').filter({ hasText: 'I agree' }).getByRole('checkbox');
+      const input = page
+        .locator('sl-form-field')
+        .filter({ hasText: 'Name' })
+        .getByRole('textbox');
+      const checkbox = page
+        .locator('sl-form-field')
+        .filter({ hasText: 'I agree' })
+        .getByRole('checkbox');
 
       await expect(input).toHaveAccessibleName('Name');
       await expect(checkbox).toHaveAccessibleName('I agree');
@@ -69,9 +97,15 @@ for (const { name, path, angularOnly } of variants) {
     });
 
     test(`should be keyboard operable`, async ({ page }) => {
-      const input = page.locator('sl-form-field').filter({ hasText: 'Name' }).getByRole('textbox');
-      const checkbox = page.locator('sl-form-field').filter({ hasText: 'I agree' }).getByRole('checkbox');
-      
+      const input = page
+        .locator('sl-form-field')
+        .filter({ hasText: 'Name' })
+        .getByRole('textbox');
+      const checkbox = page
+        .locator('sl-form-field')
+        .filter({ hasText: 'I agree' })
+        .getByRole('checkbox');
+
       await page.getByRole('button', { name: 'Collapse navigation' }).click();
       await page.keyboard.press('Tab');
       await page.keyboard.type('Test 1');
@@ -89,17 +123,31 @@ for (const { name, path, angularOnly } of variants) {
     });
 
     test(`should have accessible descriptions`, async ({ page }) => {
-      const input = page.locator('sl-form-field').filter({ hasText: 'Name' }).getByRole('textbox');
-      const checkbox = page.locator('sl-form-field').filter({ hasText: 'I agree' }).getByRole('checkbox');
+      const input = page
+        .locator('sl-form-field')
+        .filter({ hasText: 'Name' })
+        .getByRole('textbox');
+      const checkbox = page
+        .locator('sl-form-field')
+        .filter({ hasText: 'I agree' })
+        .getByRole('checkbox');
       const button = page.getByRole('button', { name: 'Confirm' });
-      
-      await expect(input).not.toHaveAccessibleDescription('Please fill in this field.');
-      await expect(checkbox).not.toHaveAccessibleDescription('Please check this box.');
-      
+
+      await expect(input).not.toHaveAccessibleDescription(
+        'Please fill in this field.',
+      );
+      await expect(checkbox).not.toHaveAccessibleDescription(
+        'Please check this box.',
+      );
+
       await button.click();
 
-      await expect(input).toHaveAccessibleDescription('Please fill in this field.');
-      await expect(checkbox).toHaveAccessibleDescription('Please check this box.');
+      await expect(input).toHaveAccessibleDescription(
+        'Please fill in this field.',
+      );
+      await expect(checkbox).toHaveAccessibleDescription(
+        'Please check this box.',
+      );
     });
   });
 }

--- a/e2e/tests/a11y/a11y-sl-switch.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-switch.spec.ts
@@ -14,7 +14,14 @@ test.describe('sl-switch accessibility', () => {
       .locator('sl-switch')
       .filter({ hasText: 'Text inside the switch' })
       .click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -29,7 +36,14 @@ test.describe('sl-switch accessibility', () => {
       .locator('sl-switch')
       .filter({ hasText: 'Text inside the switch' })
       .click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/tests/a11y/a11y-sl-text-area.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-text-area.spec.ts
@@ -11,7 +11,14 @@ test.describe('sl-text-area accessibility', () => {
     await expect(
       page.getByRole('textbox', { name: 'Text area', exact: true }),
     ).toBeVisible();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -22,7 +29,14 @@ test.describe('sl-text-area accessibility', () => {
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-text-area'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/tests/a11y/a11y-sl-toggle-button.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-toggle-button.spec.ts
@@ -14,7 +14,14 @@ test.describe('sl-toggle-button accessibility', () => {
       .locator('sl-toggle-button')
       .filter({ hasText: 'Test 1' })
       .click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -29,7 +36,14 @@ test.describe('sl-toggle-button accessibility', () => {
       .locator('sl-toggle-button')
       .filter({ hasText: 'Test 1' })
       .click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/tests/a11y/a11y-sl-tooltip.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-tooltip.spec.ts
@@ -31,7 +31,7 @@ test.describe('sl-tooltip accessibility', () => {
     page,
   }) => {
     const item = page.getByRole('button', { name: 'Button' });
-    
+
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-tooltip'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();

--- a/e2e/tests/a11y/a11y-sl-tooltip.spec.ts
+++ b/e2e/tests/a11y/a11y-sl-tooltip.spec.ts
@@ -13,7 +13,16 @@ test.describe('sl-tooltip accessibility', () => {
   test('should have no accessibility violations in standard viewport', async ({
     page,
   }) => {
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    const item = page.getByRole('button', { name: 'Button' });
+    await item.focus();
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });
@@ -21,10 +30,20 @@ test.describe('sl-tooltip accessibility', () => {
   test('should have no accessibility violations in 320px width of <main>', async ({
     page,
   }) => {
+    const item = page.getByRole('button', { name: 'Button' });
+    
     await page.setViewportSize({ width: 376, height: 667 }); // 320px width + 56px collapsed navigation
     await page.goto('/sl-tooltip'); // for Firefox to properly apply the viewport size before page load
     await page.getByRole('button', { name: 'Collapse navigation' }).click();
-    const axe = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa']);
+    await item.focus();
+    const axe = new AxeBuilder({ page }).withTags([
+      'wcag2a',
+      'wcag2aa',
+      'wcag21a',
+      'wcag21aa',
+      'wcag22a',
+      'wcag22aa',
+    ]);
     const results = await axe.analyze();
     expect(results.violations).toEqual([]);
   });

--- a/e2e/utils/getFocusedElement.ts
+++ b/e2e/utils/getFocusedElement.ts
@@ -23,34 +23,42 @@ export async function getFocusedElement(page: Page): Promise<string | null> {
 
     // Try to get innerText from the deepest element (HTMLElement only)
     const deepestText = el instanceof HTMLElement ? el.innerText.trim() : '';
-    
+
     if (deepestText) {
       return deepestText;
     }
 
     // If deepest is a form control (input, textarea, select), check for associated label via id/for attributes
-    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement || el instanceof HTMLSelectElement) {
+    if (
+      el instanceof HTMLInputElement ||
+      el instanceof HTMLTextAreaElement ||
+      el instanceof HTMLSelectElement
+    ) {
       const associatedLabelText = el.labels?.[0]?.textContent?.trim();
       if (associatedLabelText) return associatedLabelText;
-      
+
       const elementId = el.getAttribute('id');
       if (elementId) {
         // Traverse up the composed tree to find label in any shadow root or document
-        let currentRoot: Document | ShadowRoot = el.getRootNode() as Document | ShadowRoot;
-        
+        let currentRoot: Document | ShadowRoot = el.getRootNode() as
+          | Document
+          | ShadowRoot;
+
         while (currentRoot) {
           const label = Array.from(currentRoot.querySelectorAll('label')).find(
             (l) => l instanceof HTMLLabelElement && l.htmlFor === elementId,
           ) as HTMLLabelElement | undefined;
-          
+
           if (label) {
             const labelText = label.textContent?.trim();
             if (labelText) return labelText;
           }
-          
+
           // Move up to parent shadow root
           if (currentRoot instanceof ShadowRoot) {
-            currentRoot = currentRoot.host.getRootNode() as Document | ShadowRoot;
+            currentRoot = currentRoot.host.getRootNode() as
+              | Document
+              | ShadowRoot;
           } else {
             // We're at the document, no more parents
             break;
@@ -64,7 +72,8 @@ export async function getFocusedElement(page: Page): Promise<string | null> {
       const prevAriaLabel = prevEl.getAttribute('aria-label')?.trim();
       if (prevAriaLabel) return prevAriaLabel;
 
-      const prevText = prevEl instanceof HTMLElement ? prevEl.innerText.trim() : '';
+      const prevText =
+        prevEl instanceof HTMLElement ? prevEl.innerText.trim() : '';
       const MAX_PREV_TEXT_LENGTH = 100;
       // Only use prevText if it's reasonably short (avoid large container text like combobox options)
       if (prevText && prevText.length < MAX_PREV_TEXT_LENGTH) {


### PR DESCRIPTION
close: [#3535](https://github.com/sl-design-system/components/issues/3535)

- Add fix so axe-core tests are performed when tooltip is visible
- Add fixed formatting for test files
